### PR TITLE
Fix issues caused when a newer version of LDT is loaded after LDT-Unit is loaded.

### DIFF
--- a/Categories/Auras.lua
+++ b/Categories/Auras.lua
@@ -13,11 +13,7 @@ DogTag_Unit_funcs[#DogTag_Unit_funcs+1] = function(DogTag_Unit, DogTag)
 
 local L = DogTag_Unit.L
 
-local newList = DogTag.newList
-
-local hasEvent = DogTag.hasEvent
-
-local IsNormalUnit = DogTag.IsNormalUnit
+local IsNormalUnit = DogTag_Unit.IsNormalUnit
 local newList, del = DogTag.newList, DogTag.del
 
 local currentAuras, currentDebuffTypes, currentAuraTimes, currentNumDebuffs
@@ -96,7 +92,7 @@ local auraQueue = {}
 local nextAuraUpdate = 0
 local nextWackyAuraUpdate = 0
 DogTag:AddTimerHandler("Unit", function(num, currentTime)
-	if currentTime >= nextAuraUpdate and hasEvent('Aura') then
+	if currentTime >= nextAuraUpdate and DogTag.hasEvent('Aura') then
 		nextAuraUpdate = currentTime + 0.5
 		if currentTime >= nextWackyAuraUpdate then
 			nextWackyAuraUpdate = currentTime + 2

--- a/Categories/Cast.lua
+++ b/Categories/Cast.lua
@@ -17,7 +17,7 @@ local newList = DogTag.newList
 local del = DogTag.del
 local castData = {}
 local UnitGUID = UnitGUID
-local IsNormalUnit = DogTag.IsNormalUnit
+local IsNormalUnit = DogTag_Unit.IsNormalUnit
 
 local wow_ver = select(4, GetBuildInfo())
 local wow_classic = WOW_PROJECT_ID and WOW_PROJECT_ID == WOW_PROJECT_CLASSIC

--- a/Categories/Characteristics.lua
+++ b/Categories/Characteristics.lua
@@ -91,7 +91,7 @@ DogTag:AddTag("Unit", "Name", {
 		elseif unit:match("%d*vehicle%d*$") then
 			return VehicleName(unit)
 		end
-		return UnitName(unit) or DogTag.UnitToLocale[unit]
+		return UnitName(unit) or DogTag_Unit.UnitToLocale[unit]
 	end,
 	arg = {
 		'unit', 'string;undef', 'player'

--- a/Categories/Reputation.lua
+++ b/Categories/Reputation.lua
@@ -49,7 +49,7 @@ do
 		return wrap(iter)
 	end
 end
-DogTag.IterateFactions = IterateFactions
+DogTag_Unit.IterateFactions = IterateFactions
 
 DogTag:AddTag("Unit", "Reputation", {
 	code = function(faction)

--- a/Categories/TooltipScanning.lua
+++ b/Categories/TooltipScanning.lua
@@ -118,7 +118,7 @@ local function UPDATE_FACTION()
 		return
 	end
 	
-	for name in DogTag.IterateFactions() do
+	for name in DogTag_Unit.IterateFactions() do
 		factionList[name] = true
 	end
 	

--- a/LibDogTag-Unit-3.0.lua
+++ b/LibDogTag-Unit-3.0.lua
@@ -132,15 +132,15 @@ setmetatable(UnitToLocale, {__index=function(self, unit)
 	self[unit] = L["%s's target"]:format(self[nonTarget])
 	return self[unit]
 end})
-DogTag.UnitToLocale = UnitToLocale
+DogTag_Unit.UnitToLocale = UnitToLocale
 
 -- [""] = true added 8/26 by Cybeloras. TellMeWhen icons (which implement DogTag) don't always check a unit, in which case they fall back on "", not "player".
 -- Falling back on "player" (in TellMeWhen) is counter-intuitive. Falling back on "" doesn't seem to cause any issues.
 local IsLegitimateUnit = { [""] = true, player = true, target = true, focus = true, pet = true, playerpet = true, mouseover = true, npc = true, NPC = true, vehicle = true }
-DogTag.IsLegitimateUnit = IsLegitimateUnit
+DogTag_Unit.IsLegitimateUnit = IsLegitimateUnit
 local IsNormalUnit = { player = true, target = true, focus = true, pet = true, playerpet = true, mouseover = true }
 local WACKY_UNITS = { targettarget = true, playertargettarget = true, targettargettarget = true, playertargettargettarget = true, pettarget = true, playerpettarget = true, pettargettarget = true, playerpettargettarget = true }
-DogTag.IsNormalUnit = IsNormalUnit
+DogTag_Unit.IsNormalUnit = IsNormalUnit
 for i = 1, MAX_PARTY_MEMBERS do
 	IsLegitimateUnit["party" .. i] = true
 	IsLegitimateUnit["partypet" .. i] = true
@@ -207,6 +207,13 @@ setmetatable(IsLegitimateUnit, { __index = function(self, key)
 end, __call = function(self, key)
 	return self[key]
 end})
+
+-- Setting these on the DogTag lib root for backwards-compat with addons that are peeking at internals, e.g ThreatPlates:
+-- https://github.com/Backupiseasy/ThreatPlates/blob/79c933e25dbc3bb0b99b63f34eec97d0be9dc64d/Init.lua#L127
+-- However, they could get nulled out if a newer version of LibDogTag-3.0 is loaded later.
+DogTag.IsNormalUnit = IsNormalUnit
+DogTag.IsLegitimateUnit = IsLegitimateUnit
+DogTag.UnitToLocale = UnitToLocale
 
 local unitToGUID = {}
 local guidToUnits = {}
@@ -338,7 +345,17 @@ local function searchForNameTag(ast)
 	return false
 end
 
+
 DogTag:AddCompilationStep("Unit", "start", function(t, ast, kwargTypes, extraKwargs)
+
+	-- Since DogTag_Unit isn't upvalued in the same way that DogTag is
+	-- in the function compilation, we instead copy the functions from DogTag_Unit
+	-- that we need onto DogTag so we can used them in here.
+	-- This copy is necessary on every compilation because if a newer version 
+	-- of LibDogTag-3.0 is loaded, it will wipe the DogTag lib object.
+	DogTag.IsLegitimateUnit = DogTag_Unit.IsLegitimateUnit
+	DogTag.UnitToLocale = DogTag_Unit.UnitToLocale
+
 	if kwargTypes["unit"] then
 		t[#t+1] = [=[if not DogTag.IsLegitimateUnit[]=]
 		t[#t+1] = extraKwargs["unit"][1]
@@ -504,14 +521,15 @@ DogTag:AddEventHandler("Unit", "INSTANCE_ENCOUNTER_ENGAGE_UNIT", function(event,
 	end
 end)
 
+-- These 4 tables are safe to upvalue from DogTag
+-- because the same tables are reused across DogTag upgrades:
 local fsToKwargs = DogTag.fsToKwargs
 local fsToNSList = DogTag.fsToNSList
 local fsNeedUpdate = DogTag.fsNeedUpdate
 local fsNeedQuickUpdate = DogTag.fsNeedQuickUpdate
-local unpackNamespaceList = DogTag.unpackNamespaceList
 
 local nsListHasUnit = setmetatable({}, { __index = function(self, key)
-	for _, ns in ipairs(unpackNamespaceList[key]) do
+	for _, ns in ipairs(DogTag.unpackNamespaceList[key]) do
 		if ns == "Unit" then
 			self[key] = true
 			return true
@@ -520,13 +538,6 @@ local nsListHasUnit = setmetatable({}, { __index = function(self, key)
 	self[key] = false
 	return false
 end })
-
-local checkYield = DogTag.checkYield
-if not checkYield then
-	-- If LibDogTag doesn't include checkYield (old version)
-	-- Then just make checkYield an empty function to prevent errors.
-	checkYield = function() end
-end
 
 local nextRefreshGUIDsTime = 0
 DogTag:AddTimerHandler("Unit", function(num, currentTime)
@@ -546,6 +557,7 @@ DogTag:AddTimerHandler("Unit", function(num, currentTime)
 		DogTag:FireEvent("UnitChanged", "mouseover")
 	end
 	if currentTime >= nextUpdateWackyUnitsTime then
+		local checkYield = DogTag.checkYield
 		for unit in pairs(WACKY_UNITS) do
 			local oldGUID = unitToGUID[unit]
 			refreshGUID(unit)


### PR DESCRIPTION
See https://github.com/ascott18/TellMeWhen/issues/1873#issuecomment-801917542. 

Not exactly why this particular user had this scenario happen (LDT hasn't had an update for a considerable amount of time...), but nonetheless it is pretty clear what happened:
1) LDT loads
2) LDT-Unit loads
3) A newer version of LDT loads. Part of the upgrade process is [a wipe of the `DogTag` root library table.](https://github.com/parnic/LibDogTag-3.0/blob/master/Cleanup.lua#L21). As a result, functions that LDT-Unit stores on the DogTag library table get wiped out.

This change:
1) Moves LDT-Unit owned functions to the `DogTag_Unit` library table. It copies (some of) these to the `DogTag` table too for backwards-combat for addons that are accessing undocumented internals.
2) Removes upvaluing of any members of `DogTag` that are not safe to upvalue because they change across version upgrades