### PR TITLE
Drastically improve performance by not registering for WoW events that nothing is listening for.

### DIFF
--- a/Categories/Auras.lua
+++ b/Categories/Auras.lua
@@ -18,8 +18,6 @@ local newList, del = DogTag.newList, DogTag.del
 
 local currentAuras, currentDebuffTypes, currentAuraTimes, currentNumDebuffs
 
--- Parnic: support for cataclysm; Divine Intervention was removed
-local wow_400 = select(4, GetBuildInfo()) >= 40000
 local wow_700 = select(4, GetBuildInfo()) >= 70000
 local wow_800 = select(4, GetBuildInfo()) >= 80000
 
@@ -87,121 +85,126 @@ currentAuraTimes = setmetatable({}, mt)
 currentNumDebuffs = setmetatable({}, mt)
 mt = nil
 
-local auraQueue = {}
+local auraQueue
+DogTag:AddEventHandler("Unit", "EventRequested", function(_, event)
+	if event ~= "Aura" or auraQueue then return end
+	auraQueue = {}
 
-local nextAuraUpdate = 0
-local nextWackyAuraUpdate = 0
-DogTag:AddTimerHandler("Unit", function(num, currentTime)
-	if currentTime >= nextAuraUpdate and DogTag.hasEvent('Aura') then
-		nextAuraUpdate = currentTime + 0.5
-		if currentTime >= nextWackyAuraUpdate then
-			nextWackyAuraUpdate = currentTime + 2
-			for unit, v in pairs(currentAuras) do
-				if not IsNormalUnit[unit] then
-					currentAuras[unit] = del(v)
-					currentDebuffTypes[unit] = del(currentDebuffTypes[unit])
-					currentAuraTimes[unit] = del(currentAuraTimes[unit])
-					currentNumDebuffs[unit] = nil
+	local nextAuraUpdate = 0
+	local nextWackyAuraUpdate = 0
+	DogTag:AddTimerHandler("Unit", function(num, currentTime)
+		if currentTime >= nextAuraUpdate and DogTag.hasEvent('Aura') then
+			nextAuraUpdate = currentTime + 0.5
+			if currentTime >= nextWackyAuraUpdate then
+				nextWackyAuraUpdate = currentTime + 2
+				for unit, v in pairs(currentAuras) do
+					if not IsNormalUnit[unit] then
+						currentAuras[unit] = del(v)
+						currentDebuffTypes[unit] = del(currentDebuffTypes[unit])
+						currentAuraTimes[unit] = del(currentAuraTimes[unit])
+						currentNumDebuffs[unit] = nil
+					end
+				end
+			end
+			for unit in pairs(auraQueue) do
+				auraQueue[unit] = nil
+				local t = newList()
+				local u = newList()
+				local v = newList()
+				for i = 1, 40 do
+					local name, count, expirationTime, _
+					if wow_800 then
+						name, _, count, _, _, expirationTime = UnitAura(unit, i, "HELPFUL")
+					else
+						name, _, _, count, _, _, expirationTime = UnitAura(unit, i, "HELPFUL")
+					end
+					if not name then
+						break
+					end
+					if count == 0 then
+						count = 1
+					end
+					t[name] = (t[name] or 0) + count
+					if expirationTime and expirationTime > 0 and (not v[name] or v[name] > expirationTime) then
+						v[name] = expirationTime
+					end
+				end
+				local numDebuffs = 0
+				local isFriend = UnitIsFriend("player", unit)
+				for i = 1, 40 do
+					local name, count, dispelType, expirationTime, _
+					if wow_800 then
+						name, _, count, dispelType, _, expirationTime = UnitAura(unit, i, "HARMFUL")
+					else
+						name, _, _, count, dispelType, _, expirationTime = UnitAura(unit, i, "HARMFUL")
+					end
+					if not name then
+						break
+					end
+					if count == 0 then
+						count = 1
+					end
+					numDebuffs = numDebuffs + 1
+					t[name] = (t[name] or 0) + count
+					if isFriend and dispelType then
+						u[dispelType] = true
+					end
+					if expirationTime and expirationTime > 0 and (not v[name] or v[name] > expirationTime) then
+						v[name] = expirationTime
+					end
+				end
+				local old = rawget(currentAuras, unit) or newList()
+				local oldType = rawget(currentDebuffTypes, unit) or newList()
+				local oldTimes = rawget(currentAuraTimes, unit) or newList()
+				local changed = false
+				for k, num in pairs(t) do
+					if not old[k] then
+						changed = true
+						break
+					end
+					if num ~= old[k] then
+						changed = true
+						break
+					end
+					old[k] = nil
+				end
+				if not changed then
+					for k in pairs(old) do
+						changed = true
+						break
+					end
+				end
+				currentAuras[unit] = t
+				currentDebuffTypes[unit] = u
+				currentAuraTimes[unit] = v
+				local oldNumDebuffs = rawget(currentNumDebuffs, unit)
+				currentNumDebuffs[unit] = numDebuffs
+				old = del(old)
+				oldType = del(oldType)
+				oldTimes = del(oldTimes)
+				if changed or oldNumDebuffs ~= numDebuffs then
+					DogTag:FireEvent("Aura", unit)
 				end
 			end
 		end
-		for unit in pairs(auraQueue) do
-			auraQueue[unit] = nil
-			local t = newList()
-			local u = newList()
-			local v = newList()
-			for i = 1, 40 do
-				local name, count, expirationTime, _
-				if wow_800 then
-					name, _, count, _, _, expirationTime = UnitAura(unit, i, "HELPFUL")
-				else
-					name, _, _, count, _, _, expirationTime = UnitAura(unit, i, "HELPFUL")
-				end
-				if not name then
-					break
-				end
-				if count == 0 then
-					count = 1
-				end
-				t[name] = (t[name] or 0) + count
-				if expirationTime and expirationTime > 0 and (not v[name] or v[name] > expirationTime) then
-					v[name] = expirationTime
-				end
-			end
-			local numDebuffs = 0
-			local isFriend = UnitIsFriend("player", unit)
-			for i = 1, 40 do
-				local name, count, dispelType, expirationTime, _
-				if wow_800 then
-					name, _, count, dispelType, _, expirationTime = UnitAura(unit, i, "HARMFUL")
-				else
-					name, _, _, count, dispelType, _, expirationTime = UnitAura(unit, i, "HARMFUL")
-				end
-				if not name then
-					break
-				end
-				if count == 0 then
-					count = 1
-				end
-				numDebuffs = numDebuffs + 1
-				t[name] = (t[name] or 0) + count
-				if isFriend and dispelType then
-					u[dispelType] = true
-				end
-				if expirationTime and expirationTime > 0 and (not v[name] or v[name] > expirationTime) then
-					v[name] = expirationTime
-				end
-			end
-			local old = rawget(currentAuras, unit) or newList()
-			local oldType = rawget(currentDebuffTypes, unit) or newList()
-			local oldTimes = rawget(currentAuraTimes, unit) or newList()
-			local changed = false
-			for k, num in pairs(t) do
-				if not old[k] then
-					changed = true
-					break
-				end
-				if num ~= old[k] then
-					changed = true
-					break
-				end
-				old[k] = nil
-			end
-			if not changed then
-				for k in pairs(old) do
-					changed = true
-					break
-				end
-			end
-			currentAuras[unit] = t
-			currentDebuffTypes[unit] = u
-			currentAuraTimes[unit] = v
-			local oldNumDebuffs = rawget(currentNumDebuffs, unit)
-			currentNumDebuffs[unit] = numDebuffs
-			old = del(old)
-			oldType = del(oldType)
-			oldTimes = del(oldTimes)
-			if changed or oldNumDebuffs ~= numDebuffs then
-				DogTag:FireEvent("Aura", unit)
-			end
+	end)
+	
+	
+	DogTag:AddEventHandler("Unit", "UnitChanged", function(event, unit)
+		if rawget(currentAuras, unit) then
+			currentAuras[unit] = del(currentAuras[unit])
+			currentDebuffTypes[unit] = del(currentDebuffTypes[unit])
+			currentAuraTimes[unit] = del(currentAuraTimes[unit])
+			currentNumDebuffs[unit] = nil
+			auraQueue[unit] = true
 		end
-	end
-end)
-
-
-DogTag:AddEventHandler("Unit", "UnitChanged", function(event, unit)
-	if rawget(currentAuras, unit) then
-		currentAuras[unit] = del(currentAuras[unit])
-		currentDebuffTypes[unit] = del(currentDebuffTypes[unit])
-		currentAuraTimes[unit] = del(currentAuraTimes[unit])
-		currentNumDebuffs[unit] = nil
+	end)
+	
+	DogTag:AddEventHandler("Unit", "UNIT_AURA", function(event, unit)
 		auraQueue[unit] = true
-	end
+	end)
 end)
 
-DogTag:AddEventHandler("Unit", "UNIT_AURA", function(event, unit)
-	auraQueue[unit] = true
-end)
 
 DogTag:AddTag("Unit", "HasAura", {
 	code = function(aura, unit)

--- a/Categories/Cast.lua
+++ b/Categories/Cast.lua
@@ -28,174 +28,181 @@ DogTag:AddEventHandler("Unit", "PLAYER_LOGIN", function()
 	playerGuid = UnitGUID("player")
 end)
 
-local nextSpell, nextRank, nextTarget
-local function updateInfo(event, unit)
-	local guid = UnitGUID(unit)
-	if not guid then
-		return
-	end
-	local data = castData[guid]
-	if not data then
-		data = newList()
-		castData[guid] = data
-	end
-	
-	local spell, rank, displayName, icon, startTime, endTime
-	local channeling = false
-	if wow_800 then
-		spell, displayName, icon, startTime, endTime = UnitCastingInfo(unit)
-		rank = nil
-		if not spell then
-			spell, displayName, icon, startTime, endTime = UnitChannelInfo(unit)
-			channeling = true
+local castEventIsSetup = false
+DogTag:AddEventHandler("Unit", "EventRequested", function(_, event)
+	if event ~= "Cast" or castEventIsSetup then return end
+	castEventIsSetup = true
+		
+	local nextSpell, nextRank, nextTarget
+	local function updateInfo(event, unit)
+		local guid = UnitGUID(unit)
+		if not guid then
+			return
 		end
-	elseif wow_classic then
-		-- Classic only has an API for player spellcasts. No API for arbitrary units.
-		if unit == "player" then
-			spell, displayName, icon, startTime, endTime = CastingInfo()
+		local data = castData[guid]
+		if not data then
+			data = newList()
+			castData[guid] = data
+		end
+		
+		local spell, rank, displayName, icon, startTime, endTime
+		local channeling = false
+		if wow_800 then
+			spell, displayName, icon, startTime, endTime = UnitCastingInfo(unit)
 			rank = nil
 			if not spell then
-				spell, displayName, icon, startTime, endTime = ChannelInfo()
+				spell, displayName, icon, startTime, endTime = UnitChannelInfo(unit)
+				channeling = true
+			end
+		elseif wow_classic then
+			-- Classic only has an API for player spellcasts. No API for arbitrary units.
+			if unit == "player" then
+				spell, displayName, icon, startTime, endTime = CastingInfo()
+				rank = nil
+				if not spell then
+					spell, displayName, icon, startTime, endTime = ChannelInfo()
+					channeling = true
+				end
+			end
+		else
+			spell, rank, displayName, icon, startTime, endTime = UnitCastingInfo(unit)
+			if not spell then
+				spell, rank, displayName, icon, startTime, endTime = UnitChannelInfo(unit)
 				channeling = true
 			end
 		end
-	else
-		spell, rank, displayName, icon, startTime, endTime = UnitCastingInfo(unit)
-		if not spell then
-			spell, rank, displayName, icon, startTime, endTime = UnitChannelInfo(unit)
-			channeling = true
-		end
-	end
 
-	if spell then
-		data.spell = spell
-		rank = rank and tonumber(rank:match("%d+"))
-		data.rank = rank
-		local oldStart = data.startTime
-		startTime = startTime * 0.001
-		data.startTime = startTime
-		data.endTime = endTime * 0.001
-		if event == "UNIT_SPELLCAST_DELAYED" or event == "UNIT_SPELLCAST_CHANNEL_UPDATE" then
-			data.delay = (data.delay or 0) + (startTime - (oldStart or startTime))
-		else
-			data.delay = 0
-		end
-		if guid == playerGuid and spell == nextSpell and rank == nextRank then
-			data.target = nextTarget
-		end
-		data.casting = not channeling
-		data.channeling = channeling
-		data.fadeOut = false
-		data.stopTime = nil
-		data.stopMessage = nil
-		DogTag:FireEvent("Cast", unit)
-		return
-	end
-	
-	if not data.spell then
-		castData[guid] = del(data)
-		DogTag:FireEvent("Cast", unit)
-		return
-	end
-	
-	if event == "UNIT_SPELLCAST_FAILED" then
-		data.stopMessage = _G.FAILED
-	elseif event == "UNIT_SPELLCAST_INTERRUPTED" then
-		data.stopMessage = _G.INTERRUPTED
-	end
-	
-	data.casting = false
-	data.channeling = false
-	data.fadeOut = true
-	if not data.stopTime then
-		data.stopTime = GetTime()
-	end
-	DogTag:FireEvent("Cast", unit)
-end
-
-local guidsToFire, unitsToUpdate = {}, {}
-local function fixCastData()
-	local frame
-	local currentTime = GetTime()
-	for guid, data in pairs(castData) do
-		if data.casting then
-			if currentTime > data.endTime and playerGuid ~= guid then
-				data.casting = false
-				data.fadeOut = true
-				data.stopTime = currentTime
+		if spell then
+			data.spell = spell
+			rank = rank and tonumber(rank:match("%d+"))
+			data.rank = rank
+			local oldStart = data.startTime
+			startTime = startTime * 0.001
+			data.startTime = startTime
+			data.endTime = endTime * 0.001
+			if event == "UNIT_SPELLCAST_DELAYED" or event == "UNIT_SPELLCAST_CHANNEL_UPDATE" then
+				data.delay = (data.delay or 0) + (startTime - (oldStart or startTime))
+			else
+				data.delay = 0
 			end
-		elseif data.channeling then
-			if currentTime > data.endTime then
-				data.channeling = false
-				data.fadeOut = true
-				data.stopTime = currentTime
+			if guid == playerGuid and spell == nextSpell and rank == nextRank then
+				data.target = nextTarget
 			end
-		elseif data.fadeOut then
-			local alpha = 0
-			local stopTime = data.stopTime
-			if stopTime then
-				alpha = stopTime - currentTime + 1
-			end
-		
-			if alpha <= 0 then
-				castData[guid] = del(data)
-			end
-		else
-			castData[guid] = del(data)
-		end
-		local found = false
-		local normal = false
-		for unit in DogTag_Unit.IterateUnitsWithGUID(guid) do
-			found = unit
-			if IsNormalUnit[unit] then
-				normal = true
-				break
-			end
-		end
-		if not found then
-			if castData[guid] then
-				castData[guid] = del(data)
-			end
-		else
-			if not normal then
-				unitsToUpdate[found] = true
-			end
-			
-			guidsToFire[guid] = true
-		end
-	end
-	for unit in pairs(unitsToUpdate) do
-		updateInfo(nil, unit)
-	end
-	wipe(unitsToUpdate)
-	for guid in pairs(guidsToFire) do
-		for unit in DogTag_Unit.IterateUnitsWithGUID(guid) do
+			data.casting = not channeling
+			data.channeling = channeling
+			data.fadeOut = false
+			data.stopTime = nil
+			data.stopMessage = nil
 			DogTag:FireEvent("Cast", unit)
+			return
 		end
+		
+		if not data.spell then
+			castData[guid] = del(data)
+			DogTag:FireEvent("Cast", unit)
+			return
+		end
+		
+		if event == "UNIT_SPELLCAST_FAILED" then
+			data.stopMessage = _G.FAILED
+		elseif event == "UNIT_SPELLCAST_INTERRUPTED" then
+			data.stopMessage = _G.INTERRUPTED
+		end
+		
+		data.casting = false
+		data.channeling = false
+		data.fadeOut = true
+		if not data.stopTime then
+			data.stopTime = GetTime()
+		end
+		DogTag:FireEvent("Cast", unit)
 	end
-	wipe(guidsToFire)
-end
-DogTag:AddTimerHandler("Unit", fixCastData)
 
-DogTag:AddEventHandler("Unit", "UNIT_SPELLCAST_START", updateInfo)
-DogTag:AddEventHandler("Unit", "UNIT_SPELLCAST_CHANNEL_START", updateInfo)
-DogTag:AddEventHandler("Unit", "UNIT_SPELLCAST_STOP", updateInfo)
-DogTag:AddEventHandler("Unit", "UNIT_SPELLCAST_FAILED", updateInfo)
-DogTag:AddEventHandler("Unit", "UNIT_SPELLCAST_INTERRUPTED", updateInfo)
-DogTag:AddEventHandler("Unit", "UNIT_SPELLCAST_DELAYED", updateInfo)
-DogTag:AddEventHandler("Unit", "UNIT_SPELLCAST_CHANNEL_UPDATE", updateInfo)
-DogTag:AddEventHandler("Unit", "UNIT_SPELLCAST_CHANNEL_STOP", updateInfo)
-DogTag:AddEventHandler("Unit", "UnitChanged", updateInfo)
-
-DogTag:AddEventHandler("Unit", "UNIT_SPELLCAST_SENT", function(event, unit, spell, rank, target)
-	
-	-- The purpose of this event is to predict the next spell target.
-	-- This seems to be removed in at least wow_800
-	if unit == "player" and not wow_800 then
-		nextSpell = spell
-		nextRank = rank and tonumber(rank:match("%d+"))
-		nextTarget = target ~= "" and target or nil
+	local guidsToFire, unitsToUpdate = {}, {}
+	local function fixCastData()
+		local frame
+		local currentTime = GetTime()
+		for guid, data in pairs(castData) do
+			if data.casting then
+				if currentTime > data.endTime and playerGuid ~= guid then
+					data.casting = false
+					data.fadeOut = true
+					data.stopTime = currentTime
+				end
+			elseif data.channeling then
+				if currentTime > data.endTime then
+					data.channeling = false
+					data.fadeOut = true
+					data.stopTime = currentTime
+				end
+			elseif data.fadeOut then
+				local alpha = 0
+				local stopTime = data.stopTime
+				if stopTime then
+					alpha = stopTime - currentTime + 1
+				end
+			
+				if alpha <= 0 then
+					castData[guid] = del(data)
+				end
+			else
+				castData[guid] = del(data)
+			end
+			local found = false
+			local normal = false
+			for unit in DogTag_Unit.IterateUnitsWithGUID(guid) do
+				found = unit
+				if IsNormalUnit[unit] then
+					normal = true
+					break
+				end
+			end
+			if not found then
+				if castData[guid] then
+					castData[guid] = del(data)
+				end
+			else
+				if not normal then
+					unitsToUpdate[found] = true
+				end
+				
+				guidsToFire[guid] = true
+			end
+		end
+		for unit in pairs(unitsToUpdate) do
+			updateInfo(nil, unit)
+		end
+		wipe(unitsToUpdate)
+		for guid in pairs(guidsToFire) do
+			for unit in DogTag_Unit.IterateUnitsWithGUID(guid) do
+				DogTag:FireEvent("Cast", unit)
+			end
+		end
+		wipe(guidsToFire)
 	end
+	DogTag:AddTimerHandler("Unit", fixCastData)
+
+	DogTag:AddEventHandler("Unit", "UNIT_SPELLCAST_START", updateInfo)
+	DogTag:AddEventHandler("Unit", "UNIT_SPELLCAST_CHANNEL_START", updateInfo)
+	DogTag:AddEventHandler("Unit", "UNIT_SPELLCAST_STOP", updateInfo)
+	DogTag:AddEventHandler("Unit", "UNIT_SPELLCAST_FAILED", updateInfo)
+	DogTag:AddEventHandler("Unit", "UNIT_SPELLCAST_INTERRUPTED", updateInfo)
+	DogTag:AddEventHandler("Unit", "UNIT_SPELLCAST_DELAYED", updateInfo)
+	DogTag:AddEventHandler("Unit", "UNIT_SPELLCAST_CHANNEL_UPDATE", updateInfo)
+	DogTag:AddEventHandler("Unit", "UNIT_SPELLCAST_CHANNEL_STOP", updateInfo)
+	DogTag:AddEventHandler("Unit", "UnitChanged", updateInfo)
+
+	DogTag:AddEventHandler("Unit", "UNIT_SPELLCAST_SENT", function(event, unit, spell, rank, target)
+		
+		-- The purpose of this event is to predict the next spell target.
+		-- This seems to be removed in at least wow_800
+		if unit == "player" and not wow_800 then
+			nextSpell = spell
+			nextRank = rank and tonumber(rank:match("%d+"))
+			nextTarget = target ~= "" and target or nil
+		end
+	end)
+
 end)
 
 local blank = {}

--- a/Categories/Status.lua
+++ b/Categories/Status.lua
@@ -156,54 +156,65 @@ DogTag:AddAddonFinder("Unit", "_G", "CT_RAOptions_UpdateMTs", function(v)
 	end)
 end)
 
-local first = true
-DogTag:AddTimerHandler("Unit", function(currentTime, num)
-	if first then
-		first = false
-		PARTY_MEMBERS_CHANGED()
-	end
-	for guid in pairs(offlineTimes) do
-		for unit in DogTag_Unit.IterateUnitsWithGUID(guid) do
-			DogTag:FireEvent("OfflineDuration", unit)
-		end
-	end
-	for unit, guid in iterateGroupMembers() do
-		if UnitIsDeadOrGhost(unit) then
-			if not deadTimes[guid] then
-				deadTimes[guid] = GetTime()
-			end
-		else
-			if deadTimes[guid] then
-				deadTimes[guid] = nil
-				for unit in DogTag_Unit.IterateUnitsWithGUID(guid) do
-					DogTag:FireEvent("DeadDuration", unit)
-				end
-			end
-		end
+local durationEventNames = {
+	OfflineDuration = true,
+	DeadDuration = true,
+	AFKDuration = true,
+}
+local durationEventsAreSetup = false
+DogTag:AddEventHandler("Unit", "EventRequested", function(_, event)
+	if not durationEventNames[event] or durationEventsAreSetup then return end
+	durationEventsAreSetup = true
 
-		if UnitIsAFK(unit) then
-			if not afkTimes[guid] then
-				afkTimes[guid] = GetTime()
+	local first = true
+	DogTag:AddTimerHandler("Unit", function(currentTime, num)
+		if first then
+			first = false
+			PARTY_MEMBERS_CHANGED()
+		end
+		for guid in pairs(offlineTimes) do
+			for unit in DogTag_Unit.IterateUnitsWithGUID(guid) do
+				DogTag:FireEvent("OfflineDuration", unit)
 			end
-		else
-			if afkTimes[guid] then
-				afkTimes[guid] = nil
-				for unit in DogTag_Unit.IterateUnitsWithGUID(guid) do
-					DogTag:FireEvent("AFKDuration", unit)
+		end
+		for unit, guid in iterateGroupMembers() do
+			if UnitIsDeadOrGhost(unit) then
+				if not deadTimes[guid] then
+					deadTimes[guid] = GetTime()
+				end
+			else
+				if deadTimes[guid] then
+					deadTimes[guid] = nil
+					for unit in DogTag_Unit.IterateUnitsWithGUID(guid) do
+						DogTag:FireEvent("DeadDuration", unit)
+					end
+				end
+			end
+
+			if UnitIsAFK(unit) then
+				if not afkTimes[guid] then
+					afkTimes[guid] = GetTime()
+				end
+			else
+				if afkTimes[guid] then
+					afkTimes[guid] = nil
+					for unit in DogTag_Unit.IterateUnitsWithGUID(guid) do
+						DogTag:FireEvent("AFKDuration", unit)
+					end
 				end
 			end
 		end
-	end
-	for guid in pairs(deadTimes) do
-		for unit in DogTag_Unit.IterateUnitsWithGUID(guid) do
-			DogTag:FireEvent("DeadDuration", unit)
+		for guid in pairs(deadTimes) do
+			for unit in DogTag_Unit.IterateUnitsWithGUID(guid) do
+				DogTag:FireEvent("DeadDuration", unit)
+			end
 		end
-	end
-	for guid in pairs(afkTimes) do
-		for unit in DogTag_Unit.IterateUnitsWithGUID(guid) do
-			DogTag:FireEvent("AFKDuration", unit)
+		for guid in pairs(afkTimes) do
+			for unit in DogTag_Unit.IterateUnitsWithGUID(guid) do
+				DogTag:FireEvent("AFKDuration", unit)
+			end
 		end
-	end
+	end)
 end)
 
 DogTag:AddTag("Unit", "OfflineDuration", {
@@ -928,7 +939,7 @@ DogTag:AddTag("Unit", "StatusColor", {
 		'unit', 'string;undef', 'player'
 	},
 	ret = "string;nil",
-	events = "DeadDuration#$unit",
+	events = "DeadDuration#$unit;OfflineDuration#$unit",
 	doc = L["Return the color or wrap value with the color associated with unit's current status"],
 	example = '["Hello":StatusColor] => "|cff7f7f7fHello|r"; [StatusColor "Hello")] => "|cff7f7f7fHello"',
 	category = L["Status"]

--- a/Categories/Threat.lua
+++ b/Categories/Threat.lua
@@ -13,18 +13,10 @@ DogTag_Unit_funcs[#DogTag_Unit_funcs+1] = function(DogTag_Unit, DogTag)
 
 local L = DogTag_Unit.L
 
--- Unfortunatelly there is no way to determine the pair mob/unit who's threat changed,
--- so we just fire Threat event for now to update all tags.
 
--- Fired when mob's threat list changed
-DogTag:AddEventHandler( "Unit", "UNIT_THREAT_LIST_UPDATE", function( event, mobId )
-	DogTag:FireEvent( "Threat" )
-end )
-
--- Fired when unit's threat situation changed, not on raw threat value changes
-DogTag:AddEventHandler( "Unit", "UNIT_THREAT_SITUATION_UPDATE", function( event, unitId )
-	DogTag:FireEvent( "Threat" )
-end )
+-- UNIT_THREAT_LIST_UPDATE fires with the unitID of the hostile unit who's threat info changed.
+-- UNIT_THREAT_SITUATION_UPDATE fires with the unitID of a unit that has just begun or just ceased tanking something.
+local threatEvents = "UNIT_THREAT_LIST_UPDATE#$unit;UNIT_THREAT_SITUATION_UPDATE#$unit;UNIT_THREAT_SITUATION_UPDATE#player"
 
 DogTag:AddTag( "Unit", "IsTanking", {
 	code = function( unit )
@@ -42,7 +34,7 @@ DogTag:AddTag( "Unit", "IsTanking", {
 		'unit', 'string;undef', 'player'
 	},
 	ret = "nil;number",
-	events = "Threat",
+	events = threatEvents,
 	doc = L["Return True if you are the primary tank of the enemy unit or if friendly unit is the primary tank of your target."],
 	example = ('[IsTanking] => %q; [IsTanking] => ""'):format(L["True"]),
 	category = L["Threat"]
@@ -64,7 +56,7 @@ DogTag:AddTag( "Unit", "ThreatStatus", {
 		'unit', 'string;undef', 'player'
 	},
 	ret = "nil;number",
-	events = "Threat",
+	events = threatEvents,
 	doc = L["Return your threat status for enemy unit or threat status of friendly unit for your target as integer number (3 = securely tanking, 2 = insecurely tanking, 1 = not tanking but higher threat than tank, 0 = not tanking and lower threat than tank)."],
 	example = '[ThreatStatus] => "2"; [ThreatStatus] => ""',
 	category = L["Threat"]
@@ -125,6 +117,7 @@ DogTag:AddTag( "Unit", "UnitThreatStatusColor", {
 		'unit', 'string;undef', 'player'
 	},
 	ret = "string;nil",
+	events = threatEvents,
 	doc = L["Return the color or wrap value with the color associated with unit's threat status."],
 	example = '["100%":UnitThreatStatusColor] => "|cffff0000100%|r"; [UnitThreatStatusColor( "50%" )] => "|cffffffff50%"',
 	category = L["Threat"]
@@ -146,7 +139,7 @@ DogTag:AddTag( "Unit", "PercentThreat", {
 		'unit', 'string;undef', 'player'
 	},
 	ret = "nil;number",
-	events = "Threat",
+	events = threatEvents,
 	doc = L["Return the current threat that you have against enemy unit or that friendly unit has against your target as a percentage of the amount required to pull aggro, scaled according to the range from the mob."],
 	example = '[PercentThreat] => "50"',
 	category = L["Threat"]
@@ -168,7 +161,7 @@ DogTag:AddTag( "Unit", "RawPercentThreat", {
 		'unit', 'string;undef', 'player'
 	},
 	ret = "nil;number",
-	events = "Threat",
+	events = threatEvents,
 	doc = L["Return the current threat that you have against enemy unit or that friendly unit has against your target as a percentage of tank's current threat."],
 	example = '[RawPercentThreat] => "115"',
 	category = L["Threat"]

--- a/Cleanup.lua
+++ b/Cleanup.lua
@@ -17,9 +17,11 @@ if not DogTag_Unit then
 	return
 end
 
-local DogTag = LibStub:GetLibrary(DOGTAG_MAJOR_VERSION)
+local DogTag, DogTag_Minor = LibStub:GetLibrary(DOGTAG_MAJOR_VERSION)
 if not DogTag then
 	error(("Cannot load %s without first loading %s"):format(MAJOR_VERSION, DOGTAG_MAJOR_VERSION))
+elseif DogTag_Minor < 20210319000000 then
+	error(("%s requires a newer version of %s"):format(MAJOR_VERSION, DOGTAG_MAJOR_VERSION))
 end
 
 if oldMinor then

--- a/LibDogTag-Unit-3.0.lua
+++ b/LibDogTag-Unit-3.0.lua
@@ -41,6 +41,16 @@ else
 	frame = CreateFrame("Frame")
 end
 DogTag_Unit.frame = frame
+
+local usedEvents = {}
+DogTag:AddEventHandler("Unit", "EventRequested", function(_, event)
+	if not usedEvents[event] then
+		usedEvents[event] = true
+		pcall(frame.RegisterEvent, frame, event)
+	end
+end)
+
+
 local normalUnitsWackyDependents = {}
 
 local function fireEventForDependents(event, unit, ...)
@@ -51,7 +61,7 @@ local function fireEventForDependents(event, unit, ...)
 		end
 	end
 end
-frame:RegisterAllEvents()
+
 frame:SetScript("OnEvent", function(this, event, unit, ...)
 	fireEventForDependents(event, unit, ...)
 	if unit == "target" then
@@ -70,6 +80,13 @@ frame:SetScript("OnEvent", function(this, event, unit, ...)
 			DogTag:FireEvent(event, "party" .. num .. "pet", ...)
 			fireEventForDependents(event, "party" .. num .. "pet", ...)
 		end
+	else
+		-- event must not be a unit event, so we can unregister it
+		-- as the only purpose of this is to replay unit events
+		-- with different unit IDs. AFAIK there are no unit events
+		-- that are ever fired without a unitid, so this shouldn't
+		-- have any false positives.
+		frame:UnregisterEvent(event)
 	end
 end)
 


### PR DESCRIPTION
Dependent upon https://github.com/parnic/LibDogTag-3.0/pull/1. See that PR's description for more details on the premise here.

Notes on the changes here specifically:
- Once again, don't RegisterAllEvents because it causes a huge amount of CPU waste on nothing. Instead, only register events that have actually been asked for.
- For "special" events like `Aura`, `Cast`, etc, don't set them up unless there's a something actually utilizing them. This detection utilizes the `EventRequested` event being added in https://github.com/parnic/LibDogTag-3.0/pull/1.

Leaving as a draft until the LDT changes are merged.

Note: When viewing the diff, make sure to ignore whitespace changes:
![image](https://user-images.githubusercontent.com/5017521/111896926-231e5b80-89da-11eb-8f7d-884430c927a1.png)
