### PR TITLE
Fix reported TooltipScanning error from reputation

### DIFF
--- a/Categories/Reputation.lua
+++ b/Categories/Reputation.lua
@@ -44,7 +44,7 @@ if C_Reputation and C_Reputation.GetNumFactions then
 				else
 					yield(data.name, data.description, data.reaction, data.currentReactionThreshold, data.nextReactionThreshold, data.currentStanding)
 				end
-				en
+			end
 		end
 	end
 	function TerminateIterateFactions()

--- a/Categories/Reputation.lua
+++ b/Categories/Reputation.lua
@@ -28,21 +28,23 @@ if C_Reputation and C_Reputation.GetNumFactions then
 	local function iter()
 		for i = 1, GetNumFactions() do
 			local data = GetFactionDataByIndex(i)
-			if data.isHeader == 1 then
-				if data.isCollapsed == 1 then
-					local NumFactions = GetNumFactions()
-					ExpandFactionHeader(i)
-					currentOpenHeader = i
-					NumFactions = GetNumFactions() - NumFactions
-					for j = i+1, i+NumFactions do
-						yield(GetFactionInfo(j))
+			if data then
+				if data.isHeader == 1 then
+					if data.isCollapsed == 1 then
+						local NumFactions = GetNumFactions()
+						ExpandFactionHeader(i)
+						currentOpenHeader = i
+						NumFactions = GetNumFactions() - NumFactions
+						for j = i+1, i+NumFactions do
+							yield(GetFactionInfo(j))
+						end
+						CollapseFactionHeader(i)
+						currentOpenHeader = nil
 					end
-					CollapseFactionHeader(i)
-					currentOpenHeader = nil
+				else
+					yield(data.name, data.description, data.reaction, data.currentReactionThreshold, data.nextReactionThreshold, data.currentStanding)
 				end
-			else
-				yield(data.name, data.description, data.reaction, data.currentReactionThreshold, data.nextReactionThreshold, data.currentStanding)
-			end
+				en
 		end
 	end
 	function TerminateIterateFactions()


### PR DESCRIPTION
I'm not sure why an index that's within range of GetNumFactions would return nil data from GetFactionDataByIndex, so we probably need to figure out what's up with that. Maybe the value returned by GetNumFactions is only a valid input in some other GetFactionDataBy variant?

Ref:
* https://www.wowace.com/projects/ice-hud/issues/366
* https://www.curseforge.com/projects/5394?comment=7333